### PR TITLE
Break tests into distinct cases + test error parse

### DIFF
--- a/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FSHRunner.java
+++ b/org.hl7.fhir.publisher.core/src/main/java/org/hl7/fhir/igtools/publisher/FSHRunner.java
@@ -96,7 +96,7 @@ public class FSHRunner {
             log("Exception: "+ioex.getMessage());
             throw ioex;
         }
-        if (pumpHandler.errorCount > 0) {
+        if (pumpHandler.getErrorCount() > 0) {
             throw new IOException("Sushi failed with errors. Complete output from running Sushi : " + pumpHandler.getBufferString());
         }
     }
@@ -135,6 +135,10 @@ public class FSHRunner {
                 }
                 this.buffer.setLength(0);
             }
+        }
+
+        protected int getErrorCount() {
+            return errorCount;
         }
     }
 }

--- a/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/FSHRunnerTest.java
+++ b/org.hl7.fhir.publisher.core/src/test/java/org/hl7/fhir/igtools/publisher/FSHRunnerTest.java
@@ -2,6 +2,7 @@ package org.hl7.fhir.igtools.publisher;
 
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.function.Consumer;
 
@@ -16,10 +17,9 @@ class FSHRunnerTest {
 
     @Test
     void testMySushiHandler() throws IOException {
-        final StringBuilder stringBuilder = new StringBuilder(512);
-        final Consumer<String> stringConsumer = stringBuilder::append;
 
-        final FSHRunner.MySushiHandler mySushiHandler = new FSHRunner.MySushiHandler(stringConsumer);
+        final StringBuilder stringBuilder = new StringBuilder(512);
+        final FSHRunner.MySushiHandler mySushiHandler = getMySushiHandler(stringBuilder);
         for (final int codePoint : "1234".codePoints().toArray()) {
             mySushiHandler.write(codePoint);
         }
@@ -28,9 +28,18 @@ class FSHRunnerTest {
         mySushiHandler.write(10); // EOL
         assertEquals("", mySushiHandler.getBufferString());
         assertEquals("Sushi: 1234", stringBuilder.toString());
+    }
 
-        stringBuilder.setLength(0); // Reset the StringBuilder
+    @Nonnull
+    private static FSHRunner.MySushiHandler getMySushiHandler(StringBuilder stringBuilder) {
+        final Consumer<String> stringConsumer = stringBuilder::append;
+        return new FSHRunner.MySushiHandler(stringConsumer);
+    }
 
+    @Test
+    public void testMySushiHandlerLongStrings() throws IOException {
+        final StringBuilder stringBuilder = new StringBuilder(512);
+        final FSHRunner.MySushiHandler mySushiHandler = getMySushiHandler(stringBuilder);
         // Test long strings, larger than the initial buffer size
         final int largeLength = 500;
         for (int i = 0; i < largeLength; ++i) {
@@ -41,5 +50,23 @@ class FSHRunnerTest {
         mySushiHandler.write(10); // EOL
         assertEquals("", mySushiHandler.getBufferString());
         assertEquals(largeLength + 7, stringBuilder.toString().length());
+    }
+
+    @Test
+    void testMySushiHandlerErrors() throws IOException {
+
+        final StringBuilder stringBuilder = new StringBuilder(512);
+        final FSHRunner.MySushiHandler mySushiHandler = getMySushiHandler(stringBuilder);
+        for (final int codePoint : "1234".codePoints().toArray()) {
+            mySushiHandler.write(codePoint);
+        }
+        mySushiHandler.write(10); // EOL
+        for (final int codePoint : "  Errors: 13".codePoints().toArray()) {
+            mySushiHandler.write(codePoint);
+        }
+        mySushiHandler.write(10); // EOL
+        assertEquals("", mySushiHandler.getBufferString());
+        assertEquals("Sushi: 1234Sushi:   Errors: 13", stringBuilder.toString());
+        assertEquals(13, mySushiHandler.getErrorCount());
     }
 }


### PR DESCRIPTION
Breaks existing test case into two distinct cases and adds an additional test to ensure that error parsing still functions.